### PR TITLE
Fix ormgap plugin for Library Projects

### DIFF
--- a/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
+++ b/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
@@ -3,6 +3,7 @@ package com.github.stephanenicolas.ormgap
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.LibraryVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -53,7 +54,12 @@ public class ORMGAPPlugin implements Plugin<Project> {
       classpathFileCollection += javaCompile.classpath
       classpathFileCollection += project.files(javaCompile.destinationDir)
 
-      String variantName = ((ApplicationVariant) variant).mergedFlavor.name
+      String variantName
+      if (variant instanceof ApplicationVariant){
+        variantName = ((ApplicationVariant) variant).mergedFlavor.name
+      }else if (variant instanceof LibraryVariant){
+        variantName = ((LibraryVariant) variant).mergedFlavor.name
+      }
 
       def createConfigFileTask = "createORMLiteConfigFile${variant.name.capitalize()}"
       project.task(createConfigFileTask, type: CreateOrmLiteConfigTask) {


### PR DESCRIPTION
This fix addresses issue #1 
I have tested this in my own project which applies com.android.library. The class cast exception is no longer thrown, and the raw/ormlite_config.txt was created successfully.

Side note: in my own basic benchmarking I saved between 100-150ms on app startup (w/ 15 DAO classes)
