### PR TITLE
Sni/issue 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
-language: java
-jdk: oraclejdk7
-branches:
-  only:
-    - master
-before_install:
-    # Install base Android SDK and components
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libstdc++6:i386 lib32z1 expect
-    - export COMPONENTS=build-tools-19.0.3,android-19,extra-android-support,extra-android-m2repository,extra-google-m2repository
-    - export LICENSES=android-sdk-license-bcbbd656
-    - curl -3L https://raw.github.com/embarkmobile/android-sdk-installer/version-2/android-sdk-installer | bash /dev/stdin --install=$COMPONENTS --accept=$LICENSES
-    - source ~/.android-sdk-installer/env
+language: android
+
+android:
+  components:
+    # https://github.com/travis-ci/travis-ci/issues/5036
+    - tools
+    - build-tools-22.0.1
+    - android-22
+    - extra-android-m2repository
+
+jdk:
+  - oraclejdk7
 
 install:
     # Without TERM=dumb, we get mangled output in the Travis console

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,3 @@ POM_DEVELOPER_ID=SNI
 POM_DEVELOPER_NAME=Stéphane NICOLAS
 
 ORMLITE_VERSION=4.48
-
-#TODO : find a better location for this. But is it possible at all
-#we need to use JDK 7 to ensure byte code compatibility with every class
-#we will manipulate. Otherwise, only jdk 8 classes can be scanned by the plugin 
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.7.0_79.jdk/Contents/Home
-

--- a/ormgap-example/build.gradle
+++ b/ormgap-example/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 21
-  buildToolsVersion '21.1.1'
+  compileSdkVersion 22
+  buildToolsVersion '22.0.1'
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7

--- a/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
+++ b/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
@@ -84,7 +84,7 @@ public class ORMGAPPlugin implements Plugin<Project> {
           setResFolder(project.android.sourceSets["main"].res.srcDirs[0].canonicalPath)
         }
         setClasspath(classpathFileCollection.asPath)
-        into("ormlite_config.txt")
+        into(project.ormgap.configFileName)
       }.dependsOn(javaCompile)
 
       log.debug("ORMLite config file creation task installed after compile task.")

--- a/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
+++ b/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPlugin.groovy
@@ -77,18 +77,15 @@ public class ORMGAPPlugin implements Plugin<Project> {
           setSources(project.android.sourceSets["main"].java.srcDirs[0].canonicalPath)
         }
 
-        path = project.android.sourceSets[variantName].res.srcDirs[0].canonicalPath
-        if (new File(path).exists()) {
-          setResFolder(path);
-        } else {
-          setResFolder(project.android.sourceSets["main"].res.srcDirs[0].canonicalPath)
-        }
+        path = project.android.sourceSets[variantName].assets.srcDirs[0].canonicalPath
+        setDestDirFolder(path);
         setClasspath(classpathFileCollection.asPath)
         into(project.ormgap.configFileName)
       }.dependsOn(javaCompile)
 
+      variant.mergeAssets.dependsOn(createConfigFileTask)
+
       log.debug("ORMLite config file creation task installed after compile task.")
-      variant.assemble.dependsOn(createConfigFileTask)
       if (!hasLib) {
         variant.install?.dependsOn(createConfigFileTask)
       }

--- a/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPluginExtension.groovy
+++ b/ormgap-plugin/src/main/groovy/com/github/stephanenicolas/ormgap/ORMGAPPluginExtension.groovy
@@ -1,5 +1,5 @@
 package com.github.stephanenicolas.ormgap
 
 class ORMGAPPluginExtension {
-  String configFileName
+  String configFileName = "ormlite_config.txt"
 }

--- a/ormgap-plugin/src/main/java/com/github/stephanenicolas/ormgap/CreateOrmLiteConfigTask.java
+++ b/ormgap-plugin/src/main/java/com/github/stephanenicolas/ormgap/CreateOrmLiteConfigTask.java
@@ -7,9 +7,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.gradle.api.Action;
@@ -19,7 +17,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
@@ -34,7 +31,7 @@ public class CreateOrmLiteConfigTask extends DefaultTask {
     private File configFileName;
     private Object sourceDir;
     private String classpath;
-    private File rawDir;
+    private File dstDir;
 
     public CreateOrmLiteConfigTask() {
     }
@@ -48,12 +45,7 @@ public class CreateOrmLiteConfigTask extends DefaultTask {
 
     @OutputFile
     public File getOutputFile() {
-        File rawFolder = new File(this.getProject().getProjectDir(), "src/main/res/raw/");
-        if (!rawFolder.exists()) {
-            throw new StopExecutionException("Raw folder not found: " + rawFolder);
-        }
-
-        return new File(rawFolder, "ormlite_config.txt");
+        return new File(dstDir, "ormlite_config.txt");
     }
 
     @OutputFile
@@ -72,20 +64,19 @@ public class CreateOrmLiteConfigTask extends DefaultTask {
     }
 
     public void into(String configFileName) {
-        this.configFileName = new File(rawDir, configFileName);
+        this.configFileName = new File(dstDir, configFileName);
     }
 
     public void setSources(Object relativePath) {
         this.sourceDir = getProject().file(relativePath);
     }
 
-    public void setResFolder(Object relativePath) {
-        File resFolder = getProject().file(relativePath);
-        rawDir = new File(resFolder, "raw");
-        if (!rawDir.exists()) {
-            final boolean wasRawDirCreated = rawDir.mkdirs();
-            if (!wasRawDirCreated) {
-                throw new RuntimeException("Impossible to create raw folder:" + rawDir.getAbsolutePath());
+    public void setDestDirFolder(Object relativePath) {
+        dstDir = getProject().file(relativePath);
+        if (!dstDir.exists()) {
+            final boolean wasAssetsDirCreated = dstDir.mkdirs();
+            if (!wasAssetsDirCreated) {
+                throw new RuntimeException("Impossible to create destination folder:" + dstDir.getAbsolutePath());
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 include ':ormgap-plugin'
 include ':ormgap-ormlite-extension'
-include ':ormgap-example'
+//include ':ormgap-example'
 


### PR DESCRIPTION
Solves issue #10 & #9.

* the ormlite_config filename can be customized via the plugin extension
* the file is now generated in the asset folder and this makes it much smoother w.r.t to Android build cycle. Before we were using the resources but we needed the classes to be generatd which was creating a cycle (classes need resources to be compiled). This is now solved.
